### PR TITLE
Add verify contract automatically

### DIFF
--- a/pages/faq/eth/meta.json
+++ b/pages/faq/eth/meta.json
@@ -11,5 +11,6 @@
   "nothing-to-compile": "Nothing to compile",
   "opensea-not-showing-nfts": "OpenSea not showing my NFTs",
   "timeout-error": "Timeout error",
-  "gas-limit": "Unpredictable gas limit"
+  "gas-limit": "Unpredictable gas limit",
+  "verify-contract-automatically": "Verify contract to Etherscan automatically"
 }

--- a/pages/faq/eth/verify-contract-automatically.mdx
+++ b/pages/faq/eth/verify-contract-automatically.mdx
@@ -1,0 +1,92 @@
+---
+title: Verify contract to Etherscan automatically
+---
+
+# Verify contract to Etherscan automatically
+
+## Purpose
+
+<span>
+    Developer often deploy many contract during the development process, it can be exhausting when we should verify manually for every contract deployment. With this steps below you can make your contract become verified on Etherscan once they deployed.
+</span>
+
+## Solutions
+
+
+
+<ol>
+    <li>Install @nomiclabs/hardhat-etherscan</li>
+        ```bash
+            $ npm install --save-dev @nomiclabs/hardhat-etherscan
+        ```
+
+        
+        <span> then add the following statement to your  ```hardhat.config.js```:</span>
+        
+
+        ```js 
+            require("@nomiclabs/hardhat-etherscan");
+        ```
+        <br />
+    <li>Add your etherscan API KEY</li>
+        <span> add the following config to your ```hardhat.config.js```:</span> 
+        ```js
+
+        //hardhat.config.js
+        ...
+
+        module.exports = {
+            network: {
+                //Network config here
+            },
+            //Add this
+            etherscan: {
+                // Your API key for etherscan 
+                apiKey: "YOUR_ETHERSCAN_API_KEY"
+            }
+        };
+        ```
+        <span>if you don't have an Etherscan API key, you can have one from <a href="https://etherscan.io/">etherscan.io</a>.</span><br /> <br />
+        
+        
+    <li>Configure your deploy scripts</li>
+        <span>On your deploy scripts use this following statement after ```await contract.deployed()``` :</span>
+        ```js 
+        //scripts/deploy.js
+
+        const main = async() => {
+            const contractFactory = await hre.ethers.getContractFactory("ContractName");
+            const contract = await contractFactory.deploy(args1, args2);
+            await contract.deployed();
+
+            //add code below
+            //To make sure contract fully deployed 
+            await contract.deployTransaction.wait();
+
+            //to verify contract on Etherscan
+            await hre.run("verify:verify", {
+                address: contract.address, //contract address
+                constructorArguments: [ //constructor argument
+                    //you can keep this empty if your contract doesn't have constructor arguments
+                    args1, //sample argument
+                    args2  //sample argument
+                ]
+            });
+        };
+
+        ...
+        ```
+        <li>Deploy your contract</li>
+        deploy your contract as usual using this:
+        ```js
+            $ npx hardhat run scripts/deploy.js --network NETWORK
+        ```
+
+        if verification failed because of some reason and your contract still deployed, you can still verify manually using CLI:
+        ```bash
+            $ npx hardhat verify --network NETWORK DEPLOYED_CONTRACT_ADDRESS
+        ```
+
+        for more info about etherscan verification using hardhat check <a href="https://hardhat.org/plugins/nomiclabs-hardhat-etherscan"> hardhat.org</a>.
+</ol>
+


### PR DESCRIPTION
What Changes:
1. Add 1 page for eth faq, verify-contract-automatically.mdx
2. Add "Verify contract to Etherscan automatically" to meta.json

verify contract using code:
1. use @nomiclab/hardhat-etherscan
2. make contract verified right after deployment